### PR TITLE
Change listXor call to always use two lists

### DIFF
--- a/WANNRelease/WANN/wann_src/_variation.py
+++ b/WANNRelease/WANN/wann_src/_variation.py
@@ -369,7 +369,7 @@ def topoMutate(self,child,innov,gen):
     end = nodeG.shape[1]           
     if start != end:
       mutNode = np.random.randint(start,end)
-      newActPool = listXor([int(nodeG[2,mutNode])], p['ann_actRange'])
+      newActPool = listXor([int(nodeG[2,mutNode])], list(p['ann_actRange']))
       nodeG[2,mutNode] = int(newActPool[np.random.randint(len(newActPool))])
 
   child.conn = connG

--- a/WANNRelease/prettyNeatWann/neat_src/wann_ind.py
+++ b/WANNRelease/prettyNeatWann/neat_src/wann_ind.py
@@ -141,7 +141,7 @@ class WannInd(Ind):
       end = nodeG.shape[1]           
       if start != end:
         mutNode = np.random.randint(start,end)
-        newActPool = listXor([int(nodeG[2,mutNode])], p['ann_actRange'])
+        newActPool = listXor([int(nodeG[2,mutNode])], list(p['ann_actRange']))
         nodeG[2,mutNode] = int(newActPool[np.random.randint(len(newActPool))])
 
     child = WannInd(connG, nodeG)


### PR DESCRIPTION
In listXor you use sum of two lists for union, but if p['ann_actRange'] is a numpy_array (that happens when alg_act  != 0) the sum will sum alg_act to all values of the other list, instead of doing a list union, generating weird behavior