### PR TITLE
[WANN] Fix running prettyNeatWann experiments

### DIFF
--- a/WANNRelease/prettyNeatWann/p/default_wann.json
+++ b/WANNRelease/prettyNeatWann/p/default_wann.json
@@ -4,7 +4,7 @@
     "alg_nVals": 6,
     "alg_nReps": 4,
     "alg_probMoo": 0.80,
-    "alg_act": 5,
+    "alg_act": 0,
     "alg_speciate": "none",
     "maxGen": 1024,
     "popSize": 128,


### PR DESCRIPTION
The default `alg_act` for prettyNeatWann experiments was "5" (originally from NEAT code), but this resulted in [list of possible activations only to be "5"s](https://github.com/google/brain-tokyo-workshop/blob/58c50a5e42b9aab42ca2a4b3aaf3e3c66a3a5832/WANNRelease/prettyNeatWann/neat_src/neat.py#L156), meaning the activation was not mutated. Later in training this also crashed the code as it tried to pick random activation from an empty list.

A small change, but I hope this saves somebody from the headache. Looks like "WANN" directory contains more mature code.

Pinging @agaier in case :).