### PR TITLE
improved algorithm for getLayer

### DIFF
--- a/WANNRelease/WANN/wann_src/ind.py
+++ b/WANNRelease/WANN/wann_src/ind.py
@@ -172,16 +172,13 @@ def getLayer(wMat):
   wMat[wMat!=0]=1
   nNode = np.shape(wMat)[0]
   layer = np.zeros((nNode))
-  while (True): # Loop until sorting is stable
-    prevOrder = np.copy(layer)
-    for curr in range(nNode):
-      srcLayer=np.zeros((nNode))
-      for src in range(nNode):
-        srcLayer[src] = layer[src]*wMat[src,curr]   
-      layer[curr] = np.max(srcLayer)+1    
-    if all(prevOrder==layer):
-      break
-  return layer-1
+  iNodes = np.nonzero(wMat.sum(axis=0)==0)
+  i = 1
+  while iNodes[0].size > 0:
+    iNodes = np.nonzero(wMat[iNodes].sum(axis=0))
+    layer[iNodes] = i
+    i+=1
+  return layer
 
 
 # -- ANN Activation ------------------------------------------------------ -- #


### PR DESCRIPTION
The original algorithm uses multiple sorts. The new version uses the adjacency matrix to calculate the layer variable and is faster. In addition, the solution looks more readable. Let me explain the point.
The first step of the algorithm is to figure out the input nodes. In an oriented graph, they have no input oriented edges.
During each subsequent iteration, their neighbors are searched, together with assigning them a higher value in the layer index.
If a node that has already been searched for is encountered, its value is changed anyway